### PR TITLE
Remove outdated python package to fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     git \
     locales \
-    python \
     python3 \
     zsh
 


### PR DESCRIPTION
I've tried it out, the docker image did not build, the python package is no longer available and it appears to be unused thats why I removed it to make the image build again.